### PR TITLE
feat: migrate AI layer from Google Generative AI to requesty.ai

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "dpp-app",
 			"version": "0.0.1",
 			"dependencies": {
-				"@google/generative-ai": "^0.24.1",
+				"openai": "^6.32.0",
 				"pocketbase": "^0.26.8"
 			},
 			"devDependencies": {
@@ -461,15 +461,6 @@
 			],
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/@google/generative-ai": {
-			"version": "0.24.1",
-			"resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
-			"integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/@jridgewell/gen-mapping": {
@@ -1287,6 +1278,27 @@
 				"https://opencollective.com/debug"
 			],
 			"license": "MIT"
+		},
+		"node_modules/openai": {
+			"version": "6.32.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.32.0.tgz",
+			"integrity": "sha512-j3k+BjydAf8yQlcOI7WUQMQTbbF5GEIMAE2iZYCOzwwB3S2pCheaWYp+XZRNAch4jWVc52PMDGRRjutao3lLCg==",
+			"license": "Apache-2.0",
+			"bin": {
+				"openai": "bin/cli"
+			},
+			"peerDependencies": {
+				"ws": "^8.18.0",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"ws": {
+					"optional": true
+				},
+				"zod": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"vite": "^7.3.1"
 	},
 	"dependencies": {
-		"@google/generative-ai": "^0.24.1",
+		"openai": "^6.32.0",
 		"pocketbase": "^0.26.8"
 	}
 }

--- a/src/lib/ai.server.ts
+++ b/src/lib/ai.server.ts
@@ -1,0 +1,14 @@
+import OpenAI from 'openai';
+import { env } from '$env/dynamic/private';
+
+export function getAIClient(): OpenAI {
+    const apiKey = env.REQUESTY_API_KEY ?? '';
+    if (!apiKey) throw new Error('REQUESTY_API_KEY not configured');
+
+    return new OpenAI({
+        apiKey,
+        baseURL: 'https://router.requesty.ai/v1'
+    });
+}
+
+export const AI_MODEL = env.AI_MODEL ?? 'openai/gpt-4o-mini';

--- a/src/routes/api/ai/+server.ts
+++ b/src/routes/api/ai/+server.ts
@@ -1,6 +1,6 @@
 import { json, error } from '@sveltejs/kit';
-import { GoogleGenerativeAI } from '@google/generative-ai';
 import { env } from '$env/dynamic/private';
+import { getAIClient, AI_MODEL } from '$lib/ai.server';
 import type { RequestHandler } from './$types';
 
 const SYSTEM_INSTRUCTION = `Du bist ein Experte für den digitalen EU-Produktpass (DPP) und EU-Nachhaltigkeitsvorschriften. 
@@ -10,9 +10,11 @@ Fokussiere auf: EU-Ökodesign-Verordnung (ESPR), Batterieverordnung, WEEE, REACH
 Gib konkrete, umsetzbare Empfehlungen mit klarer Struktur.`;
 
 export const POST: RequestHandler = async ({ request }) => {
-	const apiKey = env.VITE_GEMINI_API_KEY ?? env.GEMINI_API_KEY ?? '';
-	if (!apiKey) {
-		throw error(500, 'GEMINI_API_KEY not configured');
+	let client;
+	try {
+		client = getAIClient();
+	} catch {
+		throw error(500, 'REQUESTY_API_KEY not configured');
 	}
 
 	const body = await request.json().catch(() => null);
@@ -25,20 +27,20 @@ export const POST: RequestHandler = async ({ request }) => {
 		history: { role: string; content: string }[];
 	};
 
-	const genAI = new GoogleGenerativeAI(apiKey);
-	const model = genAI.getGenerativeModel({
-		model: 'gemini-1.5-flash',
-		systemInstruction: SYSTEM_INSTRUCTION
+	const messages: { role: 'system' | 'user' | 'assistant'; content: string }[] = [
+		{ role: 'system', content: SYSTEM_INSTRUCTION },
+		...history.map((msg) => ({
+			role: (msg.role === 'user' ? 'user' : 'assistant') as 'user' | 'assistant',
+			content: msg.content
+		})),
+		{ role: 'user', content: message }
+	];
+
+	const completion = await client.chat.completions.create({
+		model: AI_MODEL,
+		messages
 	});
 
-	const chatHistory = history.map((msg: { role: string; content: string }) => ({
-		role: msg.role === 'user' ? 'user' : 'model',
-		parts: [{ text: msg.content }]
-	}));
-
-	const chat = model.startChat({ history: chatHistory });
-	const result = await chat.sendMessage(message);
-	const text = result.response.text();
-
+	const text = completion.choices[0]?.message?.content ?? '';
 	return json({ text });
 };

--- a/src/routes/api/ai/analyze/+server.ts
+++ b/src/routes/api/ai/analyze/+server.ts
@@ -1,21 +1,19 @@
 import { json, error } from '@sveltejs/kit';
-import { GoogleGenerativeAI } from '@google/generative-ai';
-import { env } from '$env/dynamic/private';
+import { getAIClient, AI_MODEL } from '$lib/ai.server';
 import type { RequestHandler } from './$types';
 
 export const POST: RequestHandler = async ({ request }) => {
-	const apiKey = env.VITE_GEMINI_API_KEY ?? env.GEMINI_API_KEY ?? '';
-	if (!apiKey) {
-		throw error(500, 'GEMINI_API_KEY not configured');
+	let client;
+	try {
+		client = getAIClient();
+	} catch {
+		throw error(500, 'REQUESTY_API_KEY not configured');
 	}
 
 	const body = await request.json().catch(() => null);
 	if (!body?.productData) {
 		throw error(400, 'Missing productData');
 	}
-
-	const genAI = new GoogleGenerativeAI(apiKey);
-	const model = genAI.getGenerativeModel({ model: 'gemini-1.5-flash' });
 
 	const prompt = `Analysiere folgende Produktdaten für die EU-DPP-Konformität:
 
@@ -30,6 +28,10 @@ Erstelle eine strukturierte Analyse mit:
 
 Antworte auf Deutsch mit klarer Struktur und Überschriften.`;
 
-	const result = await model.generateContent(prompt);
-	return json({ text: result.response.text() });
+	const completion = await client.chat.completions.create({
+		model: AI_MODEL,
+		messages: [{ role: 'user', content: prompt }]
+	});
+
+	return json({ text: completion.choices[0]?.message?.content ?? '' });
 };

--- a/src/routes/api/ai/calculate/+server.ts
+++ b/src/routes/api/ai/calculate/+server.ts
@@ -1,21 +1,19 @@
 import { json, error } from '@sveltejs/kit';
-import { GoogleGenerativeAI } from '@google/generative-ai';
-import { env } from '$env/dynamic/private';
+import { getAIClient, AI_MODEL } from '$lib/ai.server';
 import type { RequestHandler } from './$types';
 
 export const POST: RequestHandler = async ({ request }) => {
-	const apiKey = env.VITE_GEMINI_API_KEY ?? env.GEMINI_API_KEY ?? '';
-	if (!apiKey) {
-		throw error(500, 'GEMINI_API_KEY not configured');
+	let client;
+	try {
+		client = getAIClient();
+	} catch {
+		throw error(500, 'REQUESTY_API_KEY not configured');
 	}
 
 	const body = await request.json().catch(() => null);
 	if (!body?.productData) {
 		throw error(400, 'Missing productData');
 	}
-
-	const genAI = new GoogleGenerativeAI(apiKey);
-	const model = genAI.getGenerativeModel({ model: 'gemini-1.5-flash' });
 
 	const prompt = `Berechne einen DPP-Konformitätsscore für folgende Produktdaten:
 
@@ -47,8 +45,11 @@ WICHTIG: Antworte NUR mit einem validen JSON-Objekt, kein Markdown, keine Erklä
   "summary": "<kurze Zusammenfassung auf Deutsch>"
 }`;
 
-	const result = await model.generateContent(prompt);
-	const text = result.response.text().trim();
+	const completion = await client.chat.completions.create({
+		model: AI_MODEL,
+		messages: [{ role: 'user', content: prompt }]
+	});
+	const text = (completion.choices[0]?.message?.content ?? '').trim();
 
 	// Extract JSON: prefer the largest match to capture the full object
 	const fullMatch = text.match(/\{[\s\S]*\}/)?.[0];

--- a/src/routes/api/ai/research/+server.ts
+++ b/src/routes/api/ai/research/+server.ts
@@ -1,21 +1,19 @@
 import { json, error } from '@sveltejs/kit';
-import { GoogleGenerativeAI } from '@google/generative-ai';
-import { env } from '$env/dynamic/private';
+import { getAIClient, AI_MODEL } from '$lib/ai.server';
 import type { RequestHandler } from './$types';
 
 export const POST: RequestHandler = async ({ request }) => {
-	const apiKey = env.VITE_GEMINI_API_KEY ?? env.GEMINI_API_KEY ?? '';
-	if (!apiKey) {
-		throw error(500, 'GEMINI_API_KEY not configured');
+	let client;
+	try {
+		client = getAIClient();
+	} catch {
+		throw error(500, 'REQUESTY_API_KEY not configured');
 	}
 
 	const body = await request.json().catch(() => null);
 	if (!body?.productName) {
 		throw error(400, 'Missing productName');
 	}
-
-	const genAI = new GoogleGenerativeAI(apiKey);
-	const model = genAI.getGenerativeModel({ model: 'gemini-1.5-flash' });
 
 	const prompt = `Recherchiere EU-DPP-relevante Informationen für folgendes Produkt:
 Produkt: ${body.productName}
@@ -31,6 +29,10 @@ Analysiere und berichte über:
 
 Erstelle einen praxisorientierten Bericht auf Deutsch.`;
 
-	const result = await model.generateContent(prompt);
-	return json({ text: result.response.text() });
+	const completion = await client.chat.completions.create({
+		model: AI_MODEL,
+		messages: [{ role: 'user', content: prompt }]
+	});
+
+	return json({ text: completion.choices[0]?.message?.content ?? '' });
 };


### PR DESCRIPTION
Closes #2

## Zusammenfassung

Ersetzt den bisherigen Google Generative AI Layer durch **requesty.ai** als provider-agnostischen KI-Router.

## Änderungen

### Neue Datei
- `src/lib/ai.server.ts` – zentraler AI-Client (OpenAI SDK mit requesty.ai als baseURL)

### Geänderte Dateien
| Datei | Änderung |
|-------|---------|
| `package.json` | `@google/generative-ai` → `openai` |
| `src/routes/api/ai/+server.ts` | Google SDK → OpenAI Chat Completions |
| `src/routes/api/ai/analyze/+server.ts` | Google SDK → OpenAI Chat Completions |
| `src/routes/api/ai/calculate/+server.ts` | Google SDK → OpenAI Chat Completions |
| `src/routes/api/ai/research/+server.ts` | Google SDK → OpenAI Chat Completions |

## Erforderliche Env-Variable

```env
REQUESTY_API_KEY=<api-key>
AI_MODEL=openai/gpt-4o-mini   # optional, beliebiges requesty.ai-Modell möglich
```